### PR TITLE
AppyNox-133 Adding CORS to Gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 All notable changes to AppyNox will be documented in this file.
 
 ## [1.0.4](https://github.com/HappiSoftware/AppyNox/compare/v1.0.3...v1.0.4) - NOT RELEASED
-
+### Added
+- Adding CORS to Gateway ([#133](https://github.com/HappiSoftware/AppyNox/issues/133))
 
 ## [1.0.3](https://github.com/HappiSoftware/AppyNox/compare/v1.0.2...v1.0.3) - 2024.01.19
 ### Added

--- a/docs/appsettings.md
+++ b/docs/appsettings.md
@@ -717,6 +717,9 @@ Since appsettings files are gitignored, you must create the `appsettings.{Enviro
   },
   "ConsulConfiguration": {
     "Address": "http://localhost:8500"
+  },
+  "Cors": {
+    "AllowedOrigins": ["http://localhost:3000"]
   }
 }
 ```
@@ -751,6 +754,9 @@ Since appsettings files are gitignored, you must create the `appsettings.{Enviro
   },
   "ConsulConfiguration": {
     "Address": "http://appynox-consul:8500"
+  },
+  "Cors": {
+    "AllowedOrigins": []
   }
 }
 ```
@@ -785,6 +791,9 @@ Since appsettings files are gitignored, you must create the `appsettings.{Enviro
   },
   "ConsulConfiguration": {
     "Address": "http://appynox-consul:8500"
+  },
+  "Cors": {
+    "AllowedOrigins": []
   }
 }
 ```

--- a/src/Gateways/AppyNox.Gateway.OcelotGateway/appsettings.json
+++ b/src/Gateways/AppyNox.Gateway.OcelotGateway/appsettings.json
@@ -24,5 +24,9 @@
   },
   "ConsulConfiguration": {
     "Address": "http://localhost:8500"
+  },
+  "Cors": {
+    "AllowedOrigins": [
+    ]
   }
 }


### PR DESCRIPTION
- Added Cors settings to Ocelot Gateway.
- AllowedOrigins are fetched from appsettings.
- Update docs
closes #133 