### PR TITLE
AppyNox-161 NoxContextMiddleware Should Allow Swagger

### DIFF
--- a/src/Services/.BaseService/AppyNox.Services.Base.API/Middleware/NoxContextMiddleware.cs
+++ b/src/Services/.BaseService/AppyNox.Services.Base.API/Middleware/NoxContextMiddleware.cs
@@ -32,7 +32,14 @@ namespace AppyNox.Services.Base.API.Middleware
         {
             try
             {
+                if (context.Request.Path.StartsWithSegments("/swagger"))
+                {
+                    await _next(context);
+                    return;
+                }
+
                 string? correlationId = context.Request.Headers["X-Correlation-ID"].FirstOrDefault();
+
                 if (string.IsNullOrEmpty(correlationId) || !Guid.TryParse(correlationId, out Guid parsedCorrelationId))
                 {
                     _logger.LogCritical(new MissingCorrelationIdException(), NoxApiResourceService.MissingCorrelationIdMessage);

--- a/src/Services/.BaseService/AppyNox.Services.Base.API/Permissions/NoxJwtAuthenticationHandler.cs
+++ b/src/Services/.BaseService/AppyNox.Services.Base.API/Permissions/NoxJwtAuthenticationHandler.cs
@@ -30,10 +30,15 @@ namespace AppyNox.Services.Base.API.Permissions
 
         protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
         {
-            var endpoint = Context.GetEndpoint();
-            var requestPath = Context.Request.Path.ToString();
-            bool healthEndpoint = requestPath.Equals("/api/health");
-            if (endpoint?.Metadata?.GetMetadata<IAllowAnonymous>() != null || healthEndpoint)
+            Endpoint? endpoint = Context.GetEndpoint();
+            if (endpoint == null)
+            {
+                return AuthenticateResult.NoResult();
+            }
+
+            string requestPath = Context.Request.Path.ToString();
+            var bypassAuthPaths = new[] { "/api/health", "/swagger" };
+            if (endpoint?.Metadata?.GetMetadata<IAllowAnonymous>() != null || bypassAuthPaths.Contains(requestPath))
             {
                 // Bypass authentication for this request
                 return AuthenticateResult.NoResult();


### PR DESCRIPTION
- NoxContextMiddleware allows swagger endpoints
- Adjusted NoxJwtAuthenticationHandler to allow swagger
- NoxJwtAuthenticationHandler will not throw null token anymore if the requested endpoint does not exists 
closes #161