### PR TITLE
AppyNox-163 NoxResponseWrapperMiddleware Error

### DIFF
--- a/src/Services/.BaseService/AppyNox.Services.Base.API/Wrappers/NoxApiExceptionWrapObject.cs
+++ b/src/Services/.BaseService/AppyNox.Services.Base.API/Wrappers/NoxApiExceptionWrapObject.cs
@@ -1,24 +1,34 @@
 ﻿using AppyNox.Services.Base.Core.ExceptionExtensions.Base;
 
-namespace AppyNox.Services.Base.API.Wrappers
+namespace AppyNox.Services.Base.API.Wrappers;
+
+/// <summary>
+/// Represents a wrapper object for API exceptions, used for standardizing error responses.
+/// </summary>
+internal class NoxApiExceptionWrapObject(NoxException error, Guid correlationId)
 {
-    /// <summary>
-    /// Represents a wrapper object for API exceptions, used for standardizing error responses.
-    /// </summary>
-    internal class NoxApiExceptionWrapObject(NoxException error, Guid correlationId)
-    {
-        #region [ Properties ]
+    #region [ Properties ]
 
-        public int ExceptionCode { get; set; } = error.ExceptionCode;
+    public int ExceptionCode { get; set; } = error.ExceptionCode;
 
-        public string Title { get; set; } = $"{error.Service} {error.Layer}";
+    public string Title { get; set; } = $"{error.Service} {error.Layer}";
 
-        public string Message { get; set; } = error.Message;
+    public string Message { get; set; } = error.Message;
 
-        public Guid CorrelationId { get; set; } = correlationId;
+    public Guid CorrelationId { get; set; } = correlationId;
 
-        public Exception? InnerException { get; set; } = error.InnerException;
+    public NoxSimpleExceptionData? InnerException { get; set; } = error.InnerException != null ? new NoxSimpleExceptionData(error.InnerException) : null;
 
-        #endregion
-    }
+    #endregion
+}
+
+internal class NoxSimpleExceptionData(Exception exception)
+{
+    #region [ Properties ]
+
+    public string Message { get; set; } = exception.Message;
+
+    public string? StackTrace { get; set; } = exception.StackTrace;
+
+    #endregion
 }


### PR DESCRIPTION
WriteResponseAsync should be able to handle Exception in Body

- NoxResponseWrapperMiddleware is able to handle NoxExceptions with InnerException.
- Refactor on NoxResponseWrapperMiddleware
closes #163 