### PR TITLE
AppyNox-186 Failed C.I. Runs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Create Sso Service appsettings
         run: |
-          echo '${{ secrets.AUTHENTICATION_APPSETTINGS_STAGING }}' > ./src/Services/SsoService/AppyNox.Services.Sso.WebAPI/appsettings.Staging.json
-          echo '${{ secrets.AUTHENTICATION_APPSETTINGS_PRODUCTION }}' > ./src/Services/SsoService/AppyNox.Services.Sso.WebAPI/appsettings.Production.json
+          echo '${{ secrets.SSO_APPSETTINGS_STAGING }}' > ./src/Services/SsoService/AppyNox.Services.Sso.WebAPI/appsettings.Staging.json
+          echo '${{ secrets.SSO_APPSETTINGS_PRODUCTION }}' > ./src/Services/SsoService/AppyNox.Services.Sso.WebAPI/appsettings.Production.json
 
       - name: Create Coupon Service appsettings
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to AppyNox will be documented in this file.
 ## [1.3.0](https://github.com/HappiSoftware/AppyNox/compare/v1.2.0...v1.3.0) - NOT RELEASED
 ### Fixed
 - NoxJwtAuthenticationHandler Should Validate Token Time ([#179](https://github.com/HappiSoftware/AppyNox/issues/179))
+- Failed C.I. Runs ([#186](https://github.com/HappiSoftware/AppyNox/issues/186))
 
 ### Added
 - Pagination Data Should be Returned in Response ([#173](https://github.com/HappiSoftware/AppyNox/issues/173))


### PR DESCRIPTION
- redis.acl added to C.I. pipeline
- Authentication renamed to SSO in C.I. workflow file
- changelog updated
closing #186 