### PR TITLE
AppyNox-250 Generic Nox Repository should handle Domain entity returns

### DIFF
--- a/src/Services/.BaseService/AppyNox.Services.Base.Application/MediatR/Handlers/DDD/CreateNoxEntityCommandHandler.cs
+++ b/src/Services/.BaseService/AppyNox.Services.Base.Application/MediatR/Handlers/DDD/CreateNoxEntityCommandHandler.cs
@@ -62,7 +62,7 @@ internal sealed class CreateNoxEntityCommandHandler<TEntity>(
             await _repository.AddAsync(mappedEntity);
             await _unitOfWork.SaveChangesAsync(NoxContext.UserId.ToString());
             await UpdateTotalCountOnCache(_cacheService, $"total-count-{typeof(TEntity).Name}", true);
-            return mappedEntity.GetTypedId;
+            return mappedEntity.GetTypedId();
         }
         catch (Exception ex) when (ex is INoxException)
         {

--- a/src/Services/.BaseService/AppyNox.Services.Base.Domain/AggregateMember.cs
+++ b/src/Services/.BaseService/AppyNox.Services.Base.Domain/AggregateMember.cs
@@ -1,0 +1,5 @@
+﻿namespace AppyNox.Services.Base.Domain;
+
+public abstract class AggregateMember : AggregateRoot
+{
+}

--- a/src/Services/.BaseService/AppyNox.Services.Base.Domain/Interfaces/IHasStronglyTypedId.cs
+++ b/src/Services/.BaseService/AppyNox.Services.Base.Domain/Interfaces/IHasStronglyTypedId.cs
@@ -8,7 +8,7 @@ public interface IHasStronglyTypedId
 {
     #region [ Public Methods ]
 
-    Guid GetTypedId { get; }
+    Guid GetTypedId();
 
     #endregion
 }

--- a/src/Services/.BaseService/AppyNox.Services.Base.Domain/Interfaces/IValueObject.cs
+++ b/src/Services/.BaseService/AppyNox.Services.Base.Domain/Interfaces/IValueObject.cs
@@ -1,0 +1,6 @@
+﻿namespace AppyNox.Services.Base.Domain.Interfaces;
+
+public interface IValueObject
+{
+    // Marker interface
+}

--- a/src/Services/.BaseService/AppyNox.Services.Base.Infrastructure/ExceptionExtensions/Base/NoxInfrastructureException.cs
+++ b/src/Services/.BaseService/AppyNox.Services.Base.Infrastructure/ExceptionExtensions/Base/NoxInfrastructureException.cs
@@ -4,7 +4,7 @@ using AppyNox.Services.Base.Core.ExceptionExtensions.Base;
 
 namespace AppyNox.Services.Base.Infrastructure.ExceptionExtensions.Base
 {
-    #region [ NoxInfrastructureException Code]
+    #region [ NoxInfrastructureException Code ]
 
     internal enum NoxInfrastructureExceptionCode
     {

--- a/src/Services/.BaseService/AppyNox.Services.Base.Infrastructure/Repositories/GenericRepositoryBase.cs
+++ b/src/Services/.BaseService/AppyNox.Services.Base.Infrastructure/Repositories/GenericRepositoryBase.cs
@@ -87,6 +87,10 @@ public abstract class GenericRepositoryBase<TEntity> : IGenericRepositoryBase<TE
     /// <returns>A task representing the asynchronous operation, returning the retrieved entity.</returns>
     /// <exception cref="EntityNotFoundException{TEntity}">Thrown when the entity with the specified ID is not found.</exception>
     /// <exception cref="NoxInfrastructureException">Thrown when there is an error retrieving the entity from the database.</exception>
+    /// <remarks>
+    /// <para>Use <see cref="GetByIdAsync"/> instead. This method will be removed in v1.8.0.</para>
+    /// </remarks>
+    [Obsolete("Use GetByIdAsync instead. This method will be removed in v1.8.0")]
     public async Task<TEntity> GetEntityByIdAsync(Guid id)
     {
         try

--- a/src/Services/CouponService/AppyNox.Services.Coupon.Application/Dtos/CouponDetailDtos/Models/Basic/CouponDetailSimpleDto.cs
+++ b/src/Services/CouponService/AppyNox.Services.Coupon.Application/Dtos/CouponDetailDtos/Models/Basic/CouponDetailSimpleDto.cs
@@ -23,7 +23,7 @@ public class CouponDetailSimpleDto : IHasCode
 
     #region [ Relations ]
 
-    public IEnumerable<CouponDetailTagSimpleDto>? CouponDetailTags { get; set; }
+    public ICollection<CouponDetailTagSimpleDto>? CouponDetailTags { get; set; }
 
     #endregion
 }

--- a/src/Services/CouponService/AppyNox.Services.Coupon.Application/MediatR/Handlers/UpdateCouponCommandHandler.cs
+++ b/src/Services/CouponService/AppyNox.Services.Coupon.Application/MediatR/Handlers/UpdateCouponCommandHandler.cs
@@ -61,8 +61,8 @@ public class UpdateCouponCommandHandler(
             #endregion
 
             CouponId couponId = _mapper.Map<CouponIdDto, CouponId>(request.Dto.Id);
-
-            Domain.Coupons.Coupon entity = await _repository.GetEntityByIdAsync(couponId);
+            Domain.Coupons.Coupon? entity = (await _repository.GetByIdAsync(couponId, typeof(Domain.Coupons.Coupon)) as Domain.Coupons.Coupon)
+                ?? throw new NoxCouponApplicationException("GetByIdAsync returned null", (int)NoxCouponApplicationExceptionCode.UnexpectedUpdateCommandError);
 
             _repository.Update(entity);
 

--- a/src/Services/CouponService/AppyNox.Services.Coupon.Domain/Coupons/Coupon.cs
+++ b/src/Services/CouponService/AppyNox.Services.Coupon.Domain/Coupons/Coupon.cs
@@ -61,9 +61,9 @@ public class Coupon : AggregateRoot, IHasStronglyTypedId, IHasCode
 
     #endregion
 
-    #region [ IEntityTypeId ]
+    #region [ IHasStronglyTypedId ]
 
-    Guid IHasStronglyTypedId.GetTypedId => Id.Value;
+    public Guid GetTypedId() => Id.Value;
 
     #endregion
 
@@ -84,13 +84,20 @@ public class Coupon : AggregateRoot, IHasStronglyTypedId, IHasCode
     #endregion
 }
 
-public sealed record CouponId(Guid Value) : IHasGuidId
+public sealed record CouponId : IHasGuidId, IValueObject
 {
+    private CouponId() { }
+    public CouponId(Guid value)
+    {
+        Value = value;
+    }
+    public Guid Value { get; private set; }
     public Guid GetGuidValue() => Value;
 }
 
-public sealed record Amount
+public sealed record Amount : IValueObject
 {
+    private Amount() { }
     public double DiscountAmount { get; private set; }
 
     public int MinAmount { get; private set; }

--- a/src/Services/CouponService/AppyNox.Services.Coupon.Domain/Coupons/CouponDetail.cs
+++ b/src/Services/CouponService/AppyNox.Services.Coupon.Domain/Coupons/CouponDetail.cs
@@ -4,7 +4,7 @@ using AppyNox.Services.Coupon.Domain.Coupons.Builders;
 
 namespace AppyNox.Services.Coupon.Domain.Coupons;
 
-public class CouponDetail : AggregateRoot, IHasStronglyTypedId, IHasCode
+public class CouponDetail : AggregateMember, IHasStronglyTypedId, IHasCode
 {
     #region [ Properties ]
 
@@ -14,9 +14,9 @@ public class CouponDetail : AggregateRoot, IHasStronglyTypedId, IHasCode
 
     #endregion
 
-#nullable disable
-
     #region [ Constructors ]
+
+#nullable disable
 
     private CouponDetail()
     {
@@ -45,25 +45,20 @@ public class CouponDetail : AggregateRoot, IHasStronglyTypedId, IHasCode
 
     #endregion
 
-    #region [ IEntityTypeId ]
+    #region [ IHasStronglyTypedId ]
 
-    Guid IHasStronglyTypedId.GetTypedId => Id.Value;
+    public Guid GetTypedId() => Id.Value;
 
     #endregion
 }
 
-public sealed record CouponDetailId : IHasGuidId
+public sealed record CouponDetailId : IHasGuidId, IValueObject
 {
-    public Guid Value { get; private set; }
-    Guid IHasGuidId.GetGuidValue()
-    {
-        return Value;
-    }
-    private CouponDetailId()
-    {
-    }
+    private CouponDetailId() { }
     public CouponDetailId(Guid value)
     {
         Value = value;
     }
+    public Guid Value { get; private set; }
+    public Guid GetGuidValue() => Value;
 }

--- a/src/Services/CouponService/AppyNox.Services.Coupon.Domain/Coupons/CouponDetailTag.cs
+++ b/src/Services/CouponService/AppyNox.Services.Coupon.Domain/Coupons/CouponDetailTag.cs
@@ -4,7 +4,7 @@ using AppyNox.Services.Coupon.Domain.Coupons.Builders;
 
 namespace AppyNox.Services.Coupon.Domain.Coupons;
 
-public class CouponDetailTag : AggregateRoot, IHasStronglyTypedId
+public class CouponDetailTag : AggregateMember, IHasStronglyTypedId
 {
     #region [ Properties ]
 
@@ -33,9 +33,9 @@ public class CouponDetailTag : AggregateRoot, IHasStronglyTypedId
 
     #endregion
 
-    #region [ IEntityTypeId ]
+    #region [ IHasStronglyTypedId ]
 
-    public Guid GetTypedId => Id.Value;
+    public Guid GetTypedId() => Id.Value;
 
     #endregion
 
@@ -46,18 +46,13 @@ public class CouponDetailTag : AggregateRoot, IHasStronglyTypedId
     #endregion
 }
 
-public sealed record CouponDetailTagId : IHasGuidId
+public sealed record CouponDetailTagId : IHasGuidId, IValueObject
 {
-    public Guid Value { get; private set; }
-    Guid IHasGuidId.GetGuidValue()
-    {
-        return Value;
-    }
-    private CouponDetailTagId()
-    {
-    }
+    private CouponDetailTagId() { }
     public CouponDetailTagId(Guid value)
     {
         Value = value;
     }
+    public Guid Value { get; private set; }
+    public Guid GetGuidValue() => Value;
 }

--- a/src/Services/CouponService/AppyNox.Services.Coupon.Domain/Coupons/CouponHistory.cs
+++ b/src/Services/CouponService/AppyNox.Services.Coupon.Domain/Coupons/CouponHistory.cs
@@ -3,7 +3,7 @@ using AppyNox.Services.Base.Domain.Interfaces;
 
 namespace AppyNox.Services.Coupon.Domain.Coupons;
 
-public sealed class CouponHistory : AggregateRoot, IHasStronglyTypedId
+public sealed class CouponHistory : AggregateMember, IHasStronglyTypedId
 {
     #region [ Properties ]
 
@@ -23,7 +23,7 @@ public sealed class CouponHistory : AggregateRoot, IHasStronglyTypedId
 
     #region [ IHasStronglyTypedId ]
 
-    public Guid GetTypedId => Id.Value;
+    public Guid GetTypedId() => Id.Value;
 
     #endregion
 
@@ -53,8 +53,14 @@ public sealed class CouponHistory : AggregateRoot, IHasStronglyTypedId
 
 #region [ Value Objects ]
 
-public sealed record CouponHistoryId(Guid Value) : IHasGuidId
+public sealed record CouponHistoryId : IHasGuidId
 {
+    private CouponHistoryId() { }
+    public CouponHistoryId(Guid value)
+    {
+        Value = value;
+    }
+    public Guid Value { get; private set; }
     public Guid GetGuidValue() => Value;
 }
 

--- a/src/Services/CouponService/Tests/UnitTests/AppyNox.Services.Coupon.Infrastructure.UnitTest/RepositoryTests/CouponRepositoryUnitTest.cs
+++ b/src/Services/CouponService/Tests/UnitTests/AppyNox.Services.Coupon.Infrastructure.UnitTest/RepositoryTests/CouponRepositoryUnitTest.cs
@@ -53,8 +53,10 @@ public class CouponRepositoryUnitTest : IClassFixture<RepositoryFixture>
 
     #region [ Read ]
 
-    [Fact]
-    public async Task GetAllAsync_ShouldReturnEntity()
+    [Theory]
+    [InlineData(typeof(CouponAggregate))]
+    [InlineData(typeof(CouponSimpleDto))]
+    public async Task GetAllAsync_ShouldReturnEntity(Type fetchType)
     {
         CouponDbContext context = RepositoryFixture.CreateDatabaseContext<CouponDbContext>();
         UnitOfWork unitOfWork = new(context, _noxLoggerStub);
@@ -68,7 +70,7 @@ public class CouponRepositoryUnitTest : IClassFixture<RepositoryFixture>
             PageSize = 1,
         };
 
-        var result = await repository.GetAllAsync(queryParameters, typeof(CouponSimpleDto), _cacheService);
+        var result = await repository.GetAllAsync(queryParameters, fetchType, _cacheService);
 
         Assert.NotNull(result);
         Assert.Single(result.Items);

--- a/src/Services/LicenseService/AppyNox.Services.License.Domain/Entities/ApplicationUserLicenseMacAddress.cs
+++ b/src/Services/LicenseService/AppyNox.Services.License.Domain/Entities/ApplicationUserLicenseMacAddress.cs
@@ -2,7 +2,7 @@
 
 namespace AppyNox.Services.License.Domain.Entities
 {
-    public class ApplicationUserLicenseMacAddress : IHasStronglyTypedId
+    public class ApplicationUserLicenseMacAddress
     {
         #region [ Properties ]
 
@@ -17,12 +17,6 @@ namespace AppyNox.Services.License.Domain.Entities
         public Guid ApplicationUserLicenseId { get; set; }
 
         public virtual ApplicationUserLicenses ApplicationUserLicense { get; set; } = null!;
-
-        #endregion
-
-        #region [ IEntityTypeId ]
-
-        Guid IHasStronglyTypedId.GetTypedId => Id;
 
         #endregion
     }

--- a/src/Services/LicenseService/AppyNox.Services.License.Domain/Entities/ApplicationUserLicenses.cs
+++ b/src/Services/LicenseService/AppyNox.Services.License.Domain/Entities/ApplicationUserLicenses.cs
@@ -2,7 +2,7 @@
 
 namespace AppyNox.Services.License.Domain.Entities
 {
-    public class ApplicationUserLicenses : IHasStronglyTypedId
+    public class ApplicationUserLicenses
     {
         #region [ Properties ]
 
@@ -19,12 +19,6 @@ namespace AppyNox.Services.License.Domain.Entities
         public virtual LicenseEntity License { get; set; } = default!;
 
         public virtual ICollection<ApplicationUserLicenseMacAddress>? MacAddresses { get; set; }
-
-        #endregion
-
-        #region [ IEntityTypeId ]
-
-        Guid IHasStronglyTypedId.GetTypedId => Id;
 
         #endregion
     }

--- a/src/Services/LicenseService/AppyNox.Services.License.Domain/Entities/LicenseEntity.cs
+++ b/src/Services/LicenseService/AppyNox.Services.License.Domain/Entities/LicenseEntity.cs
@@ -35,9 +35,9 @@ public class LicenseEntity : AggregateRoot, IHasStronglyTypedId, IHasCode
 
     #endregion
 
-    #region [ IEntityTypeId ]
+    #region [ IHasStronglyTypedId ]
 
-    Guid IHasStronglyTypedId.GetTypedId => Id.Value;
+    public Guid GetTypedId() => Id.Value;
 
     #endregion
 

--- a/src/Services/LicenseService/AppyNox.Services.License.Domain/Entities/ProductEntity.cs
+++ b/src/Services/LicenseService/AppyNox.Services.License.Domain/Entities/ProductEntity.cs
@@ -1,6 +1,5 @@
 ﻿using AppyNox.Services.Base.Domain;
 using AppyNox.Services.Base.Domain.Interfaces;
-using System.ComponentModel.Design;
 
 namespace AppyNox.Services.License.Domain.Entities;
 
@@ -26,9 +25,9 @@ public class ProductEntity : AggregateRoot, IHasStronglyTypedId, IHasCode
 
     #endregion
 
-    #region [ IEntityTypeId ]
+    #region [ IHasStronglyTypedId ]
 
-    Guid IHasStronglyTypedId.GetTypedId => Id.Value;
+    public Guid GetTypedId() => Id.Value;
 
     #endregion
 

--- a/src/Services/SsoService/AppyNox.Services.Sso.Domain/Entities/CompanyEntity.cs
+++ b/src/Services/SsoService/AppyNox.Services.Sso.Domain/Entities/CompanyEntity.cs
@@ -2,7 +2,7 @@
 
 namespace AppyNox.Services.Sso.Domain.Entities;
 
-public class CompanyEntity : IHasStronglyTypedId, IHasCode
+public class CompanyEntity : IHasCode
 {
     #region [ Properties ]
 
@@ -23,12 +23,6 @@ public class CompanyEntity : IHasStronglyTypedId, IHasCode
     public virtual ICollection<ApplicationUser>? Users { get; set; }
 
     public virtual ICollection<ApplicationRole>? Roles { get; set; }
-
-    #endregion
-
-    #region [ IEntityTypeId ]
-
-    Guid IHasStronglyTypedId.GetTypedId => Id;
 
     #endregion
 }


### PR DESCRIPTION
- GetEntityById methods marked as Obsolote.
- Get methods are accepting entity type returns.
- A test modified for this case
- AggregateItem introduced. Works same as AggregateRoot
- IValueObject added. It's a marker interface
- IHasStronglyTypeId changed to method instead of property.
- closes #250