### PR TITLE
AppyNox-327 Feature request: InfrastructureServiceBuilder Should Allow Multiple Schemens

### DIFF
--- a/src/Services/.BaseService/AppyNox.Services.Base.Application/MediatR/Commands/NoxEntityCommands.cs
+++ b/src/Services/.BaseService/AppyNox.Services.Base.Application/MediatR/Commands/NoxEntityCommands.cs
@@ -21,6 +21,6 @@ public record CreateNoxEntityCommand<TEntity>(dynamic Dto, string DetailLevel) :
     where TEntity : class, IHasStronglyTypedId;
 
 [SuppressMessage("Sonar Code Smell", "S2326:Unused type parameters should be removed", Justification = "TEntity is used to specify the type of entity being created")]
-public record DeleteNoxEntityCommand<TEntity, TId>(TId Id, bool ForceDelete) : IRequest
+public record DeleteNoxEntityCommand<TEntity, TId>(TId Id, bool ForceDelete = false) : IRequest
     where TEntity : class, IHasStronglyTypedId
     where TId : NoxId;

--- a/src/Services/CouponService/AppyNox.Services.Coupon.Infrastructure/DependencyInjection.cs
+++ b/src/Services/CouponService/AppyNox.Services.Coupon.Infrastructure/DependencyInjection.cs
@@ -32,8 +32,18 @@ public static class DependencyInjection
             options.UseConsul = true;
             options.UseRedis = true;
             options.UseJwtAuthentication = true;
-            options.Claims = [.. Permissions.Coupons.Metrics];
-            options.AdminClaims = [.. Permissions.CouponsAdmin.Metrics];
+            options.AuthorizationSchemes =
+            [
+                new()
+                {
+                    Permissions = [.. Permissions.Coupons.Metrics],
+                },
+                new()
+                {
+                    IsAdmin = true,
+                    Permissions = [.. Permissions.CouponsAdmin.Metrics]
+                }
+            ];
             options.Configuration = configuration;
             options.UseMassTransit = true;
         });

--- a/src/Services/LicenseService/AppyNox.Services.License.Infrastructure/DependencyInjection.cs
+++ b/src/Services/LicenseService/AppyNox.Services.License.Infrastructure/DependencyInjection.cs
@@ -27,7 +27,13 @@ namespace AppyNox.Services.License.Infrastructure
                 options.UseConsul = true;
                 options.UseRedis = true;
                 options.UseJwtAuthentication = true;
-                options.Claims = [.. Permissions.Licenses.Metrics, .. Permissions.Products.Metrics];
+                options.AuthorizationSchemes =
+                [
+                    new()
+                    {
+                        Permissions = [.. Permissions.Licenses.Metrics, .. Permissions.Products.Metrics],
+                    }
+                ];
                 options.Configuration = configuration;
                 options.UseMassTransit = true;
                 options.MassTransitConfiguration = busConfigurator =>

--- a/src/Services/SsoService/AppyNox.Services.Sso.Infrastructure/Data/Configurations/ApplicationRoleClaimConfiguration.cs
+++ b/src/Services/SsoService/AppyNox.Services.Sso.Infrastructure/Data/Configurations/ApplicationRoleClaimConfiguration.cs
@@ -59,7 +59,7 @@ namespace AppyNox.Services.Sso.Infrastructure.Data.Configurations
                 new IdentityRoleClaim<Guid> { Id = 22, RoleId = _adminRoleId, ClaimType = "API.Permission", ClaimValue = "Products.Edit" },
                 new IdentityRoleClaim<Guid> { Id = 23, RoleId = _adminRoleId, ClaimType = "API.Permission", ClaimValue = "Products.Delete" },
 
-                // NotAdmin Role Claims
+                // NotAdmin Role Permissions
                 new IdentityRoleClaim<Guid> { Id = 19, RoleId = _notAdminRoleId, ClaimType = "API.Permission", ClaimValue = "Coupons.View" }
             );
 

--- a/src/Services/SsoService/AppyNox.Services.Sso.Infrastructure/DependencyInjection.cs
+++ b/src/Services/SsoService/AppyNox.Services.Sso.Infrastructure/DependencyInjection.cs
@@ -54,7 +54,13 @@ public static class DependencyInjection
             options.UseConsul = true;
             options.UseRedis = true;
             options.UseJwtAuthentication = false;
-            options.Claims = [.. Permissions.Users.Metrics, .. Permissions.Roles.Metrics];
+            options.AuthorizationSchemes =
+            [
+                new()
+                {
+                    Permissions = [.. Permissions.Users.Metrics, .. Permissions.Roles.Metrics]
+                }
+            ];
             options.Configuration = configuration;
             options.UseMassTransit = true;
             options.MassTransitConfiguration = busConfigurator =>

--- a/src/Services/SsoService/AppyNox.Services.Sso.WebAPI/Controllers/RolesController.cs
+++ b/src/Services/SsoService/AppyNox.Services.Sso.WebAPI/Controllers/RolesController.cs
@@ -185,7 +185,7 @@ public class RolesController(IMapper mapper, RoleManager<ApplicationRole> roleMa
 
     [HttpPost]
     [Authorize(Roles.AssignPermission)]
-    [Route("/api/Roles/{rid}/Claims")]
+    [Route("/api/Roles/{rid}/Permissions")]
     public async Task<IActionResult> AssignClaim(Guid rid, [FromBody] ClaimDto claim)
     {
         var role = await _roleManager.FindByIdAsync(rid.ToString())
@@ -222,7 +222,7 @@ public class RolesController(IMapper mapper, RoleManager<ApplicationRole> roleMa
 
     [HttpDelete]
     [Authorize(Roles.WithdrawPermission)]
-    [Route("/api/Roles/{rid}/Claims/{claimValue}")]
+    [Route("/api/Roles/{rid}/Permissions/{claimValue}")]
     public async Task<IActionResult> WithdrawClaim(Guid rid, string claimValue)
     {
         var role = await _roleManager.FindByIdAsync(rid.ToString())


### PR DESCRIPTION
- InfrastructureSetupOptions and InfrastructureServiceBuilder modified to support different authorization schemes.
- DeleteNoxEntityCommand ForceDelete parameter marked as optional.
- closes #327